### PR TITLE
[FEAT] vite 번들 분리 및 highlight.js dynamic import 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "msw": "^2.6.5",
     "prettier": "^3.3.3",
     "puppeteer": "^23.9.0",
+    "rollup-plugin-visualizer": "^5.14.0",
     "storybook": "^8.4.5",
     "stylelint": "^16.10.0",
     "stylelint-config-prettier-scss": "^1.0.0",

--- a/src/features/archive/ui/MarkdownPreview.tsx
+++ b/src/features/archive/ui/MarkdownPreview.tsx
@@ -1,41 +1,30 @@
-import hljs from 'highlight.js';
-import { marked } from 'marked';
-import { markedHighlight } from 'marked-highlight';
+import { useEffect, useState } from 'react';
 
-import 'highlight.js/styles/github.css';
 import styles from './MarkdownPreview.module.scss';
 
-marked.use(
-  markedHighlight({
-    langPrefix: 'hljs language-',
-    highlight(code, lang) {
-      if (code.trim() === '') {
-        return hljs.highlight('', { language: 'plaintext' }).value;
-      }
-
-      if (lang && hljs.getLanguage(lang)) {
-        return hljs.highlight(code, { language: lang }).value;
-      }
-      return hljs.highlight(code, { language: 'plaintext' }).value;
-    },
-  }),
-);
-
-marked.setOptions({
-  breaks: true,
-  gfm: true,
-});
+import { marked } from '@/shared/lib/mark';
 
 type MarkdownPreviewProps = {
   markdownText: string;
 };
 
 export const MarkdownPreview = ({ markdownText }: MarkdownPreviewProps) => {
+  const [htmlContent, setHtmlContent] = useState('');
+  //console.log(htmlContent);
+
+  useEffect(() => {
+    const parsingText = async () => {
+      const html = await marked.parse(markdownText);
+      setHtmlContent(html);
+    };
+    void parsingText();
+  }, [markdownText]);
+
   return (
     <div
       className={styles.mirror}
       dangerouslySetInnerHTML={{
-        __html: marked(markdownText),
+        __html: htmlContent,
       }}
     />
   );

--- a/src/features/gathering/ui/GatheringMarkdownPreview.tsx
+++ b/src/features/gathering/ui/GatheringMarkdownPreview.tsx
@@ -1,41 +1,29 @@
-import hljs from 'highlight.js';
-import { marked } from 'marked';
-import { markedHighlight } from 'marked-highlight';
+import { useEffect, useState } from 'react';
 
-import 'highlight.js/styles/github.css';
 import styles from './GatheringMarkdownPreview.module.scss';
 
-marked.use(
-  markedHighlight({
-    langPrefix: 'hljs language-',
-    highlight(code, lang) {
-      if (code.trim() === '') {
-        return hljs.highlight('', { language: 'plaintext' }).value;
-      }
-
-      if (lang && hljs.getLanguage(lang)) {
-        return hljs.highlight(code, { language: lang }).value;
-      }
-      return hljs.highlight(code, { language: 'plaintext' }).value;
-    },
-  }),
-);
-
-marked.setOptions({
-  breaks: true,
-  gfm: true,
-});
+import { marked } from '@/shared/lib/mark';
 
 interface MarkdownPreviewProps {
   markdownText: string;
 }
 
 export const GatheringMarkdownPreview = ({ markdownText }: MarkdownPreviewProps) => {
+  const [htmlContent, setHtmlContent] = useState('');
+
+  useEffect(() => {
+    const parsingText = async () => {
+      const html = await marked.parse(markdownText);
+      setHtmlContent(html);
+    };
+    void parsingText();
+  }, [markdownText]);
+
   return (
     <div
       className={styles.mirror}
       dangerouslySetInnerHTML={{
-        __html: marked(markdownText),
+        __html: htmlContent,
       }}
     />
   );

--- a/src/shared/lib/mark.ts
+++ b/src/shared/lib/mark.ts
@@ -1,0 +1,45 @@
+import hljs from 'highlight.js/lib/core';
+import plaintext from 'highlight.js/lib/languages/plaintext';
+import { Marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+
+import type { HljsLangType } from '../model/hljsLangList';
+import { hljsLangModules } from '../model/hljsLangList';
+
+import 'highlight.js/styles/github.css';
+
+hljs.registerLanguage('plaintext', plaintext);
+
+const isHljsLang = (key: string): key is HljsLangType => {
+  return key in hljsLangModules;
+};
+
+const asyncHighlight = async (code: string, lang: string) => {
+  if (lang && !isHljsLang(lang)) {
+    lang = 'plaintext';
+  } else if (lang && isHljsLang(lang) && !hljs.getLanguage(lang)) {
+    try {
+      // 동적으로 해당 언어 모듈 import 시도
+      const langModule = await hljsLangModules[lang]();
+      hljs.registerLanguage(lang, langModule.default);
+    } catch (error) {
+      console.error(`"${lang}" module load failed`, error);
+      lang = 'plaintext';
+    }
+  }
+  // 하이라이팅 수행 (언어가 없으면 plaintext 사용)
+  const highlighted = hljs.highlight(code, { language: lang || 'plaintext' }).value;
+  return highlighted;
+};
+
+export const marked = new Marked(
+  markedHighlight({
+    async: true,
+    highlight: asyncHighlight,
+  }),
+);
+
+marked.setOptions({
+  breaks: true,
+  gfm: true,
+});

--- a/src/shared/model/hljsLangList.ts
+++ b/src/shared/model/hljsLangList.ts
@@ -1,0 +1,20 @@
+export type HljsLangType = keyof typeof hljsLangModules;
+
+export const hljsLangModules = {
+  plaintext: () => import('highlight.js/lib/languages/plaintext.js'),
+  javascript: () => import('highlight.js/lib/languages/javascript.js'),
+  typescript: () => import('highlight.js/lib/languages/typescript.js'),
+  python: () => import('highlight.js/lib/languages/python.js'),
+  java: () => import('highlight.js/lib/languages/java.js'),
+  c: () => import('highlight.js/lib/languages/c.js'),
+  cpp: () => import('highlight.js/lib/languages/cpp.js'),
+  csharp: () => import('highlight.js/lib/languages/csharp.js'),
+  php: () => import('highlight.js/lib/languages/php.js'),
+  go: () => import('highlight.js/lib/languages/go.js'),
+  swift: () => import('highlight.js/lib/languages/swift.js'),
+  kotlin: () => import('highlight.js/lib/languages/kotlin.js'),
+  ruby: () => import('highlight.js/lib/languages/ruby.js'),
+  sql: () => import('highlight.js/lib/languages/sql.js'),
+  bash: () => import('highlight.js/lib/languages/bash.js'),
+  json: () => import('highlight.js/lib/languages/json.js'),
+} as const;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import path from 'path';
 import svgr from 'vite-plugin-svgr';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -10,7 +11,17 @@ export default defineConfig({
     port: 3000,
     open: true,
   },
-  plugins: [react(), tsconfigPaths(), svgr()],
+  plugins: [
+    react(),
+    tsconfigPaths(),
+    svgr(),
+    visualizer({
+      filename: './dist/stats.html',
+      template: 'treemap',
+      gzipSize: true,
+      brotliSize: true,
+    }),
+  ],
   css: {
     preprocessorOptions: {
       scss: {
@@ -31,5 +42,51 @@ export default defineConfig({
   },
   define: {
     global: 'window',
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (
+            id.includes('node_modules/@codemirror') ||
+            id.includes('node_modules/@lezer') ||
+            id.includes('node_modules/@uiw')
+          ) {
+            return 'editor';
+          }
+
+          if (
+            id.includes('highlight.js/lib/languages/') ||
+            id.includes('highlight.js/es/languages/')
+          ) {
+            const lang = id.split('/').pop()?.replaceAll('.js', '');
+            return `hljs-${lang}`; // 개별 청크 생성
+          }
+
+          if (id.includes('node_modules/marked') || id.includes('node_modules/highlight.js')) {
+            return 'preview';
+          }
+
+          if (
+            id.includes('node_modules/react-slick') ||
+            id.includes('node_modules/react-select') ||
+            id.includes('node_modules/slick-carousel') ||
+            id.includes('node_modules/react-datepicker') ||
+            id.includes('node_modules/sweetalert2') ||
+            id.includes('node_modules/date-fns')
+          ) {
+            return 'ui';
+          }
+
+          if (id.includes('node_modules/@nivo') || id.includes('node_modules/d3')) {
+            return 'chart';
+          }
+
+          if (id.includes('node_modules')) {
+            return 'vendor';
+          }
+        },
+      },
+    },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8780,6 +8780,16 @@ robots-parser@^3.0.1:
   resolved "https://registry.yarnpkg.com/robots-parser/-/robots-parser-3.0.1.tgz#3d8a3cdfa8ac240cbb062a4bd16fcc0e0fb9ed23"
   integrity sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==
 
+rollup-plugin-visualizer@^5.14.0:
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz#be82d43fb3c644e396e2d50ac8a53d354022d57c"
+  integrity sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==
+  dependencies:
+    open "^8.4.0"
+    picomatch "^4.0.2"
+    source-map "^0.7.4"
+    yargs "^17.5.1"
+
 rollup@^4.20.0:
   version "4.27.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.27.3.tgz#078ecb20830c1de1f5486607f3e2f490269fb98a"
@@ -9091,6 +9101,11 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
 
 speedline-core@^1.4.3:
   version "1.4.3"
@@ -10343,7 +10358,7 @@ yargs@^15.4.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^17.3.1, yargs@^17.7.2:
+yargs@^17.3.1, yargs@^17.5.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->

- Closes #129 

<br/>

## 💭 작업 내용

1. rollup manualChunk를 사용하여 번들 분리
2. highlight.js 언어 모듈 dynamic import 적용
3. marked-highlight 적용 안되던 버그 수정

<br/>

## 🤔 참고 사항

<!-- PR 승인 전 확인해야 할 사항들을 설명해주세요 -->

- [ ]

<br/>

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/55ef0d21-4814-4c31-a1d0-7b5eb145bb5a)

전체 번들 사이즈 2900kb -> 2000kb

